### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = ["Etienne Batise <etienne.batise@gmail.com>"]
 edition = "2018"
 description = 'Horizontal rule for your terminal'
-repository = 'http://github.com/etiennebatise/hr-rs'
+repository = 'https://github.com/etiennebatise/hr-rs'
 license = "MIT"
 
 exclude = [


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97